### PR TITLE
Add macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.exe
 *.h
 *.so
+*.dylib

--- a/README.md
+++ b/README.md
@@ -61,3 +61,9 @@ This project is a little bit finnicky to compile and install.
 1. Copy `obs.dll` from your OBS 64-bit install (from obs-studio/bin/64bit) to the root of the exporter checkout directory.
 2. `go build -buildmode=c-shared -o obs-studio-exporter.dll`
 3. Install by copying `obs-studio-exporter.dll` to obs-studio/obs-plugins/64bit.
+
+### macOS
+
+1. Copy `libobs.so` from your OBS 64-bit install (Usually `/Applications/OBS.app/Contents/Frameworks/libobs.0.dylib`) to the root of the exporter checkout directory.
+2. `go build -buildmode=c-shared -o obs-studio-exporter.so`
+3. Install by copying `obs-studio-exporter.so` to `/Applications/OBS.app/Contents/PlugIns/`.

--- a/callbacks.go
+++ b/callbacks.go
@@ -16,7 +16,9 @@ package main
 
 /*
 #cgo CFLAGS: -Iobs-studio/libobs
-#cgo LDFLAGS: -L. -lobs
+#cgo darwin LDFLAGS: -L. -lobs.0
+#cgo linux LDFLAGS: -L. -lobs
+#cgo windows LDFLAGS: -L. -lobs
 #include <obs-module.h>
 #include <obs.h>
 

--- a/main.go
+++ b/main.go
@@ -17,7 +17,9 @@ package main
 
 /*
 #cgo CFLAGS: -Ithird_party/obs-studio/libobs
-#cgo LDFLAGS: -L. -lobs
+#cgo darwin LDFLAGS: -L. -lobs.0
+#cgo linux LDFLAGS: -L. -lobs
+#cgo windows LDFLAGS: -L. -lobs
 #include <obs-module.h>
 #include <obs.h>
 


### PR DESCRIPTION
By default `libobs` is a dylib on macOS.
Add instructions to README and use the correct name on macOS.